### PR TITLE
Add exclusion for fixture(s) and support `tests/` folder

### DIFF
--- a/packages/eslint-config-js/index.js
+++ b/packages/eslint-config-js/index.js
@@ -33,9 +33,10 @@ module.exports = {
 			{
 				devDependencies: [
 					'**/*.config.*',
+					'**/*.fixture.*',
 					'**/*.spec.*',
 					'**/*.stories.*',
-					'**/{.storybook,dev,mocks,scripts,spec,stories,test,webpack}/**',
+					'**/{.storybook,dev,fixtures,mocks,scripts,spec,stories,test(s?),webpack}/**',
 				],
 			},
 		],


### PR DESCRIPTION
Added these exclusions to support Playwright Fixtures and the standard `*.fixture.ts` or `fixtures/` folder